### PR TITLE
Bug 1298495 - Add hooks:trigger-hook:project-<project>/* to project admin roles

### DIFF
--- a/src/make-project-admin-role.js
+++ b/src/make-project-admin-role.js
@@ -24,6 +24,7 @@ module.exports.run = async (project) => {
     'auth:update-role:hook-id:project-<project>/*',
     'auth:update-role:project:<project>:*',
     'hooks:modify-hook:project-<project>/*',
+    'hooks:trigger-hook:project-<project>/*',
     'project:<project>:*',
     'queue:get-artifact:project/<project>/*',
     'queue:route:index.project.<project>.*',


### PR DESCRIPTION
As per https://docs.taskcluster.net/reference/core/hooks/api-docs#triggerHook

CC: @kmoir
