### PR TITLE
Add generic-worker test scopes to scm_level_1

### DIFF
--- a/src/make-scm-group-role.js
+++ b/src/make-scm-group-role.js
@@ -1,6 +1,15 @@
 import editRole from './util/edit-role';
 import {getProjects, hgmoPath} from './util/projects';
 
+// Additional static scopes to be added to generated lists
+var STATIC_SCOPES = {
+  // Grant any users with scm level 1 (try) access, the capability to run
+  // generic-worker unit tests. This really isn't a lot of scopes, but
+  // possibly more than we'd want to give to *anyone* so granting with scm
+  // level 1 seems like a reasonable control.
+  'scm_level_1': ['assume:project:taskcluster:generic-worker-tester']
+}
+
 module.exports.setup = (program) => {
   return program
     .command('make-scm-group-role <group>')
@@ -25,6 +34,10 @@ module.exports.run = async (group, options) => {
     return `assume:repo:hg.mozilla.org/${path}:*`;
   });
 
+  if (group in STATIC_SCOPES) {
+    scopes = scopes.concat(STATIC_SCOPES[group])
+  }
+
   var description = [
     '*DO NOT EDIT*',
     '',
@@ -40,5 +53,3 @@ module.exports.run = async (group, options) => {
     noop: options.noop,
   });
 };
-
-


### PR DESCRIPTION
@djmitche Not sure if this is a good idea or not.

Basically, sometimes users want to be able to run generic worker (e.g. taskcluster/generic-worker#53), and for this they need the test scopes. Although the test scopes are pretty basic, we probably don't want to give them to everybody. So I decided a reasonable requirement could be that you need to have SCM level 1 as that means you are already marginally vetted. I'm interested to know what you think about this idea - if it is mixing different concerns together, or it is a reasonable fit.

Next, I saw that `mozilla-group:scm_level_1` is auto-generated, so I updated the code to be able to pull in a static list of additional scopes. As I was working on this, it occurred to me that an alternative would just be to reorganise the scopes, e.g. we could grant one additional scope `assume:static:mozilla-group:scm_level_<x>` to `mozilla-group:scm_level_<x>` roles, and then e.g. define role `assume:static:mozilla-group:scm_level_1` to have `assume:project:taskcluster:generic-worker-tester`. But then I thought, this might be overengineering things, especially in light of the fact we intend to implement some kind of parameterized roles.

So this is a halfway house - no additional roles, but changes to "additional static roles" now requiring code changes. That may be a good or bad thing, depending on your point of view!

Lastly, I've little experience with node.js - so if the global var `STATIC_SCOPES` is a bad thing (or anything else I did) or if it should be done more generically across the library somehow (i.e. not just for `make-scm-group-role.js`) then let me know!

Thanks.

CC @mykmelez