### PR TITLE
Bug 1382204 - fix namespace of coalesce route

### DIFF
--- a/src/make-gecko-branch-role.js
+++ b/src/make-gecko-branch-role.js
@@ -54,7 +54,7 @@ module.exports.run = async function(projectsOption, options) {
       'queue:route:tc-treeherder.<project>.*',
       'queue:route:tc-treeherder-stage.v2.<project>.*',
       'queue:route:tc-treeherder.v2.<project>.*',
-      'queue:route:coalesce.v1.builds.<project>.*',
+      'queue:route:coalesce.v1.<project>.*',
     ].map((scope) =>
       scope
       .replace('<project>', projectName)


### PR DESCRIPTION
In bug 1382204 I dropped `.build` from coalesce routes - this change reflects that update.

Thanks!