### PR TITLE
Bug 1424335 - used parameterized roles for gecko branches

### DIFF
--- a/src/make-gecko-branch-role.js
+++ b/src/make-gecko-branch-role.js
@@ -9,6 +9,13 @@ module.exports.setup = (program) => {
     .description('create or update a gecko branch role');
 };
 
+let ALL_FEATURES = [
+  'taskcluster-docker-routes-v1',
+  'taskcluster-docker-routes-v2',
+  'buildbot',
+  'is-trunk',
+];
+
 module.exports.run = async function(projectsOption, options) {
   var taskcluster = require('taskcluster-client');
   var chalk = require('chalk');
@@ -48,64 +55,13 @@ module.exports.run = async function(projectsOption, options) {
 
     var roleId = `repo:hg.mozilla.org/${path}:*`;
     var scopes = [
-      'assume:moz-tree:level:<level>:<trust-domain>',
-      'queue:route:index.<trust-domain>.v2.<project>.*',
-      'index:insert-task:<trust-domain>.v2.<project>.*',
-      'queue:route:index.<trust-domain>.cache.level-<level>.*',
-      'index:insert-task:<trust-domain>.cache.level-<level>.*',
-      'queue:route:tc-treeherder-stage.<project>.*',
-      'queue:route:tc-treeherder.<project>.*',
-      'queue:route:tc-treeherder-stage.v2.<project>.*',
-      'queue:route:tc-treeherder.v2.<project>.*',
-      'queue:route:coalesce.v1.builds.<project>.*',  // deprecated - https://bugzilla.mozilla.org/show_bug.cgi?id=1382204
-      'queue:route:coalesce.v1.<project>.*',
-      'queue:route:index.releases.v1.<project>.*',
-      'secrets:get:project/releng/<trust-domain>/build/level-<level>/*'
-    ].map((scope) =>
-      scope
-      .replace('<trust-domain>', domain)
-      .replace('<project>', projectName)
-      .replace('<level>', level)
-    );
+      `assume:project:releng:branch:${domain}:level-${level}:${projectName}`,
+    ];
 
-    if (feature(project, 'taskcluster-docker-routes-v1')) {
-      scopes.push(...[
-        'queue:route:index.docker.images.v1.<project>.*',
-        'index:insert-task:docker.images.v1.<project>.*',
-      ].map((scope) =>
-        scope
-        .replace('<project>', projectName)
-        .replace('<level>', level)
-      ));
-    }
-
-    if (feature(project, 'taskcluster-docker-routes-v2')) {
-      scopes.push(...[
-        'queue:route:index.docker.images.v2.level-<level>.*'
-      ].map((scope) =>
-        scope
-        .replace('<project>', projectName)
-        .replace('<level>', level)
-      ));
-    }
-
-    if (feature(project, 'buildbot')) {
-      scopes.push(...[
-        'queue:route:index.buildbot.branches.<project>.*',
-        'index:insert-task:buildbot.branches.<project>.*',
-        'queue:route:index.buildbot.revisions.*',
-        'index:insert-task:buildbot.revisions.*',
-        'project:releng:buildbot-bridge:builder-name:release-<project>-*',
-        'project:releng:buildbot-bridge:builder-name:release-<project>_*',
-      ].map((scope) =>
-        scope
-        .replace('<project>', projectName)
-        .replace('<level>', level)
-      ));
-    }
-
-    if (feature(project, 'is-trunk')) {
-      scopes.push('queue:route:index.gecko.v2.trunk.revision.*');
+    for (let feat of ALL_FEATURES) {
+      if (feature(project, feat)) {
+        scopes.push(`assume:project:releng:feature:${feat}:${domain}:level-${level}:${projectName}`);
+      }
     }
 
     var description = [

--- a/src/make-gecko-parameterized-roles.js
+++ b/src/make-gecko-parameterized-roles.js
@@ -1,5 +1,5 @@
 import editRole from './util/edit-role';
-import {getProjects, hgmoPath, scmLevel, feature} from './util/projects';
+import {getProjects, hgmoPath, scmLevel, feature, ROLE_ROOTS} from './util/projects';
 
 module.exports.setup = (program) => {
   return program
@@ -24,8 +24,14 @@ module.exports.run = async function(options) {
 
   for (let level of allLevels) {
     for (let domain of allDomains) {
+      var roleRoot = ROLE_ROOTS[domain];
+      if (!roleRoot) {
+        console.log(chalk.red(`Unknown trust domain ${domain}.`));
+        process.exit(1);
+      }
+
       await editRole({
-        roleId: `project:releng:branch:${domain}:level-${level}:*`,
+        roleId: `${roleRoot}:branch:${domain}:level-${level}:*`,
         description: description(
           `Scopes for ${domain} projects at level ${level}; the '*' matches the project name.`
         ),
@@ -49,7 +55,7 @@ module.exports.run = async function(options) {
 
       let makeFeature = async (feature, scopes) => {
         await editRole({
-          roleId: `project:releng:feature:${feature}:${domain}:level-${level}:*`,
+          roleId: `${roleRoot}:feature:${feature}:${domain}:level-${level}:*`,
           description: description(
             `Scopes for ${domain} projects at level ${level} with feature '${feature}'; the '*' matches the project name.`
           ),
@@ -58,12 +64,12 @@ module.exports.run = async function(options) {
         });
       };
 
-      await makeFeature('taskcsluter-docker-routes-v1', [
+      await makeFeature('taskcluster-docker-routes-v1', [
         `queue:route:index.docker.images.v1.<..>.*`,
         `index:insert-task:docker.images.v1.<..>.*`,
       ]);
 
-      await makeFeature('taskcsluter-docker-routes-v2', [
+      await makeFeature('taskcluster-docker-routes-v2', [
         `queue:route:index.docker.images.v2.level-${level}.*`
       ]);
 

--- a/src/make-gecko-parameterized-roles.js
+++ b/src/make-gecko-parameterized-roles.js
@@ -1,0 +1,85 @@
+import editRole from './util/edit-role';
+import {getProjects, hgmoPath, scmLevel, feature} from './util/projects';
+
+module.exports.setup = (program) => {
+  return program
+    .command('make-gecko-parameterized-roles')
+    .option('-n, --noop', 'Don\'t change roles, just show difference')
+    .description('make the parameterized roles used by other gecko roles');
+};
+
+var description = desc => [
+  '*DO NOT EDIT*',
+  '',
+  desc,
+  '',
+  'This role is configured automatically by [taskcluster-admin](https://github.com/taskcluster/taskcluster-admin).',
+].join('\n');
+
+module.exports.run = async function(options) {
+  var projects = await getProjects();
+
+  var allLevels = new Set(Object.values(projects).map(proj => scmLevel(proj)));
+  var allDomains = new Set(Object.values(projects).map(proj => proj.trust_domain));
+
+  for (let level of allLevels) {
+    for (let domain of allDomains) {
+      await editRole({
+        roleId: `project:releng:branch:${domain}:level-${level}:*`,
+        description: description(
+          `Scopes for ${domain} projects at level ${level}; the '*' matches the project name.`
+        ),
+        scopes: [
+          `assume:moz-tree:level:${level}:${domain}`,
+          `queue:route:index.${domain}.v2.<..>.*`,
+          `index:insert-task:${domain}.v2.<..>.*`,
+          `queue:route:index.${domain}.cache.level-${level}.*`,
+          `index:insert-task:${domain}.cache.level-${level}.*`,
+          `queue:route:tc-treeherder-stage.<..>.*`,
+          `queue:route:tc-treeherder.<..>.*`,
+          `queue:route:tc-treeherder-stage.v2.<..>.*`,
+          `queue:route:tc-treeherder.v2.<..>.*`,
+          `queue:route:coalesce.v1.builds.<..>.*`,  // deprecated - https://bugzilla.mozilla.org/show_bug.cgi?id=1382204
+          `queue:route:coalesce.v1.<..>.*`,
+          `queue:route:index.releases.v1.<..>.*`,
+          `secrets:get:project/releng/${domain}/build/level-${level}/*`,
+        ],
+        noop: options.noop,
+      });
+
+      let makeFeature = async (feature, scopes) => {
+        await editRole({
+          roleId: `project:releng:feature:${feature}:${domain}:level-${level}:*`,
+          description: description(
+            `Scopes for ${domain} projects at level ${level} with feature '${feature}'; the '*' matches the project name.`
+          ),
+          scopes,
+          noop: options.noop,
+        });
+      };
+
+      await makeFeature('taskcsluter-docker-routes-v1', [
+        `queue:route:index.docker.images.v1.<..>.*`,
+        `index:insert-task:docker.images.v1.<..>.*`,
+      ]);
+
+      await makeFeature('taskcsluter-docker-routes-v2', [
+        `queue:route:index.docker.images.v2.level-${level}.*`
+      ]);
+
+      await makeFeature('buildbot', [
+        `queue:route:index.buildbot.branches.<..>.*`,
+        `index:insert-task:buildbot.branches.<..>.*`,
+        `queue:route:index.buildbot.revisions.*`,
+        `index:insert-task:buildbot.revisions.*`,
+        `project:releng:buildbot-bridge:builder-name:release-<..>-*`,
+        `project:releng:buildbot-bridge:builder-name:release-<..>_*`,
+      ]);
+
+      await makeFeature('is-trunk', [
+        `queue:route:index.gecko.v2.trunk.revision.*`,
+      ]);
+    }
+  }
+
+};

--- a/src/util/projects.js
+++ b/src/util/projects.js
@@ -10,6 +10,20 @@ const LEVEL_GROUPS = {
   scm_autoland: 3,
 };
 
+// each project has a set of enabled features, and we use roles for each of them.
+exports.ALL_FEATURES = [
+  'taskcluster-docker-routes-v1',
+  'taskcluster-docker-routes-v2',
+  'buildbot',
+  'is-trunk',
+];
+
+// for each trust domain, we use a different root for the parameterized roles
+exports.ROLE_ROOTS = {
+  gecko: 'project:releng',
+  comm: 'project:comm:thunderbird:comm:releng',
+};
+
 // Get the latest production-branches.json, returning the decoded data.
 exports.getProjects = async () => {
   let res = await request.get(CI_CONFIGURATION + 'projects.yml').buffer(true);


### PR DESCRIPTION
This uses the project as the parameter, and then replicates the roles
for levels and trust domains.  Believe me, supporting multiple
parameters was just not possible :)